### PR TITLE
fix: respect CLAUDE_CONFIG_DIR in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -e
 
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MARKETPLACE_DIR="$HOME/.claude/naksha-marketplace"
+MARKETPLACE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/naksha-marketplace"
 
 echo "Installing naksha..."
 


### PR DESCRIPTION

## What does this PR do?
Marketplace dir now resolves to $CLAUDE_CONFIG_DIR/naksha-marketplace when set, falling back to $HOME/.claude/naksha-marketplace otherwise.

This fixes the install for users with custom claude config folders.

## Type of change

- [ ] Other (describe below)

Small tweak to install.sh script




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin installation directory is now configurable via the `CLAUDE_CONFIG_DIR` environment variable, with automatic fallback to `$HOME/.claude`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->