### PR TITLE
Add Autohand Code CLI adapter docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Naksha Design Team — Autohand Code CLI
+
+This file activates the Naksha virtual design team when working in
+Autohand Code CLI. Naksha's canonical skill lives in
+`skills/design/SKILL.md`; use that orchestrator for any design, UI/UX,
+visual, branding, spatial, conversational, or compliance task.
+
+## How to Use Naksha
+
+1. Read `skills/design/SKILL.md` first.
+2. Follow its routing guidance to select the right design roles and
+   reference files.
+3. Use the files under `skills/design/references/` as the source of
+   truth for specialist design knowledge.
+4. For command-style workflows, read the matching file in `commands/`
+   and execute that process directly.
+
+## Operating Rules
+
+- Keep outputs production-ready: responsive, accessible, polished, and
+  specific to the user's product context.
+- Prefer existing Naksha role references over inventing new guidance.
+- When changing Naksha itself, follow `CONTRIBUTING.md` and keep
+  platform adapters in sync.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ done
 
 ## Platform Adapters
 
-Naksha runs on 5 AI coding tools. The knowledge lives in the same role reference files — adapters just surface it differently:
+Naksha runs on multiple AI coding tools. The knowledge lives in the same role reference files — adapters just surface it differently:
 
 | Tool | Adapter File | How It Loads |
 |------|-------------|-------------|
@@ -177,6 +177,7 @@ Naksha runs on 5 AI coding tools. The knowledge lives in the same role reference
 | **Windsurf** | `.windsurfrules` | Read at session start for entire project |
 | **Gemini CLI** | `GEMINI.md` | Read at session start for entire project |
 | **VS Code Copilot** | `.github/copilot-instructions.md` | Applied to Copilot Chat + inline completions |
+| **Autohand Code CLI** | `AGENTS.md` + `skills/design/` copied to `.autohand/skills/naksha-design/` | AGENTS.md project instructions + project-level skill |
 
 ### Updating Adapters
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![Windsurf](https://img.shields.io/badge/Windsurf-Rules-0099ff)]()
 [![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-GEMINI.md-4285F4)]()
 [![Copilot](https://img.shields.io/badge/Copilot-Instructions-24292e)]()
+[![Autohand Code CLI](https://img.shields.io/badge/Autohand_Code_CLI-AGENTS.md-0A84FF)](https://github.com/autohandai/code-cli)
 [![Roles](https://img.shields.io/badge/Specialist_Roles-26-orange)]()
 [![Commands](https://img.shields.io/badge/Slash_Commands-60-green)]()
 [![Design Knowledge](https://img.shields.io/badge/Design_Knowledge-13800%2B_lines-E8633A)]()
@@ -55,6 +56,10 @@ Copy `GEMINI.md` to your project root. Gemini CLI reads it at session start.
 ### VS Code Copilot
 
 Copy `.github/copilot-instructions.md` to your project's `.github/` directory. Copilot Chat and inline completions will apply the design team's rules.
+
+### Autohand Code CLI
+
+Copy `AGENTS.md` to your project root and copy `skills/design/` to `.autohand/skills/naksha-design/`. Autohand Code CLI will read the project instructions and load the Naksha design skill from its project-level skills directory.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds Autohand Code CLI as a supported way to use Naksha.

This follows the existing adapter model by adding:

- an `AGENTS.md` entry point for Autohand project instructions
- README quick-start guidance for copying the Naksha design skill into `.autohand/skills/naksha-design/`
- a CONTRIBUTING platform-adapter row so future role/rule updates keep Autohand in sync

Autohand Code CLI lives at https://github.com/autohandai/code-cli.

## Validation

- `cat evals/evals.json | python3 -m json.tool > /dev/null`
- `cat .claude-plugin/plugin.json | python3 -m json.tool > /dev/null`
- verified every `references/*.md` path mentioned by `skills/design/SKILL.md` exists
- `git diff --check`

I kept this scoped to the adapter/docs surface; no command or role behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Autohand Code CLI documentation with integration and usage guidelines
  * Updated platform adapter section to reflect support for multiple AI coding tools
  * Extended Quick Start with Autohand Code CLI setup and installation instructions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Adityaraj0421/naksha-studio/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->