### PR TITLE
fix(reel): correct inverted before/after wipe in /design-reel (v5.1.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "naksha",
       "source": "./",
       "description": "A virtual design team for Claude Code — 26 roles, 63 commands, 15,000+ lines of expert design knowledge. Your agency's design brain, inside your terminal.",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "author": {
         "name": "Aditya Raj"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "naksha",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "A virtual design team for Claude Code, Cursor, Windsurf, Gemini CLI, and Copilot — powered by Naksha. Assembles specialist roles — UI designer, UX researcher, content designer, Figma expert, data viz, email, social, motion, presentation, brand strategy, illustration, video, conversational, spatial, compliance, and more — for any design task. 26 roles, 63 commands, 15,000+ lines of expert design knowledge. Your agency's design brain, inside your terminal.",
   "author": {
     "name": "adityaraj0421"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to naksha are documented here.
 
+## v5.1.1 — `/design-reel` wipe fix (2026-06-29)
+
+**Fixed:** the before/after wipe in redesign mode (`--url`) had its sides inverted — the BEFORE label sat over the redesigned page and AFTER over the original. The wipe now keeps BEFORE on the left and reveals AFTER in from the right, matching the labels. Caught by an end-to-end redesign run (a live dashboard) that the fixture test couldn't expose. Added a code comment so the clip direction can't be silently re-inverted.
+
 ## v5.1.0 — Watch the Team: `/design-reel` (2026-06-29)
 
 naksha can now record its own design team working. `/design-reel` turns a `/design` run into a share-able vertical (9:16) + landscape (16:9) video — the 26-role team redesigning a screen, captioned, live. The team is the hook: no single-voice AI design tool can show a Creative Director, UX Designer, and UI Designer each making a distinct, visible change to the page you just designed.

--- a/meta/stats.json
+++ b/meta/stats.json
@@ -1,1 +1,1 @@
-{"version":"5.1.0","roles":26,"commands":63,"knowledge_lines":15261,"reference_files":32}
+{"version":"5.1.1","roles":26,"commands":63,"knowledge_lines":15261,"reference_files":32}

--- a/packages/naksha-reel/src/Reel.tsx
+++ b/packages/naksha-reel/src/Reel.tsx
@@ -105,12 +105,16 @@ const Reveal: React.FC<{spec: Spec; before: string; after: string; layout: Retur
   return (
     <AbsoluteFill>
       {hasBefore ? (
+        // Wipe: BEFORE stays on the LEFT, AFTER reveals in from the RIGHT (labels below
+        // match these sides). clipPath insets the LEFT by (1-p)% so `after` shows on the
+        // right p% — do NOT flip to `inset(0 (1-p)% 0 0)`, that puts AFTER on the left and
+        // inverts the BEFORE/AFTER tags.
         <>
           <PageCard box={layout.pageBox} src={before} />
-          <div style={{position: 'absolute', left: layout.pageBox.x, top: layout.pageBox.y, width: layout.pageBox.w, height: layout.pageBox.h, clipPath: `inset(0 ${(1 - p) * 100}% 0 0)`}}>
+          <div style={{position: 'absolute', left: layout.pageBox.x, top: layout.pageBox.y, width: layout.pageBox.w, height: layout.pageBox.h, clipPath: `inset(0 0 0 ${(1 - p) * 100}%)`}}>
             <PageCard box={{x: 0, y: 0, w: layout.pageBox.w, h: layout.pageBox.h}} src={after} />
           </div>
-          <div style={{position: 'absolute', left: layout.pageBox.x + layout.pageBox.w * p, top: layout.pageBox.y, width: 5, height: layout.pageBox.h, background: '#fff', boxShadow: '0 0 26px #fff', transform: 'translateX(-2px)'}} />
+          <div style={{position: 'absolute', left: layout.pageBox.x + layout.pageBox.w * (1 - p), top: layout.pageBox.y, width: 5, height: layout.pageBox.h, background: '#fff', boxShadow: '0 0 26px #fff', transform: 'translateX(-2px)'}} />
           <div style={{position: 'absolute', left: layout.pageBox.x + 12, top: layout.pageBox.y + 12, fontFamily: JBMONO, fontSize: 20, fontWeight: 700, color: '#111', background: '#fff', borderRadius: 6, padding: '5px 11px', opacity: 1 - p}}>BEFORE</div>
           <div style={{position: 'absolute', left: layout.pageBox.x + layout.pageBox.w - 96, top: layout.pageBox.y + 12, fontFamily: JBMONO, fontSize: 20, fontWeight: 700, color: '#fff', background: C.orange500, borderRadius: 6, padding: '5px 11px', opacity: p}}>AFTER</div>
         </>


### PR DESCRIPTION
## Bug

In `/design-reel` redesign mode (`--url`), the before/after wipe was inverted: the **BEFORE** label sat over the redesigned page and **AFTER** over the original. The fixture test didn't expose it (both fixture images were naksha frames); an end-to-end `--url` run on a live dashboard — ugly white original vs dark redesign — made it obvious.

## Fix

`clipPath` now insets the **left** edge (`inset(0 0 0 (1-p)%)`) so AFTER reveals in from the right while BEFORE stays on the left, matching the corner labels. Divider sweeps right→left with the reveal edge. Added a code comment so the direction can't be silently re-inverted.

## Verification

- Re-rendered the live redesign reel: BEFORE (white original) left, AFTER (dark redesign) right ✓
- `scripts/reel-render-smoke.sh` — PASS
- Patch release: **v5.1.0 → v5.1.1**

🤖 Generated with [Claude Code](https://claude.com/claude-code)