### PR TITLE
feat(site): naksha-studio landing page + GitHub Pages deploy

### DIFF
--- a/.design-lint.json
+++ b/.design-lint.json
@@ -5,6 +5,7 @@
     "demos/**",
     "assets/**",
     "brand/**",
-    "packages/**"
+    "packages/**",
+    "site/**"
   ]
 }

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,35 @@
+name: Deploy site
+
+# Publishes site/ to GitHub Pages on every push to main that touches it.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deploy at a time; let an in-progress run finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,490 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>naksha-studio — a virtual design agency in your terminal</title>
+<meta name="description" content="A virtual design agency in your terminal. 26 specialist roles, 63 commands, inside Claude Code, Cursor, Windsurf, Gemini CLI, and Copilot.">
+<meta property="og:title" content="naksha-studio — a virtual design agency in your terminal">
+<meta property="og:description" content="26 specialist roles. 63 commands. One command and the whole design agency shows up.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400..600;1,6..72,400..600&family=JetBrains+Mono:wght@400;500;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+  /* ===== naksha-studio brand: iris-blue on near-black, blueprint/draftsman ===== */
+  :root{
+    --bg:#070810; --bg2:#0C0E18; --panel:#10131F; --card:#11141E; --term:#0A0B12;
+    --line:rgba(243,244,250,.10); --line-2:rgba(243,244,250,.17);
+    --ink:#F3F4FA; --ink-soft:#9094A6; --ink-dim:#5E627A;
+    --accent:#5C50E8; --accent-soft:#8E86F4; --accent-deep:#3A30B8;
+    --grid:rgba(150,160,220,.05); --tick:rgba(150,160,220,.16);
+    --serif:"Newsreader",Georgia,serif; --mono:"JetBrains Mono",ui-monospace,monospace; --sans:"Inter",system-ui,sans-serif;
+    --max:1120px;
+  }
+  /* light theme (toggle) — keeps the iris accent, paper base */
+  html[data-theme="light"]{
+    --bg:#ECEEF5; --bg2:#F5F6FB; --panel:#FFFFFF; --card:#FFFFFF; --term:#0A0B12;
+    --line:rgba(20,22,44,.10); --line-2:rgba(20,22,44,.17);
+    --ink:#14162A; --ink-soft:#585C72; --ink-dim:#9094A6;
+    --grid:rgba(60,70,150,.06); --tick:rgba(60,70,150,.20); --accent-soft:#5247DE;
+  }
+  *{box-sizing:border-box;margin:0}
+  html{scroll-behavior:smooth}
+  body{font-family:var(--sans);color:var(--ink);background:var(--bg);line-height:1.5;-webkit-font-smoothing:antialiased;overflow-x:hidden;transition:background .4s,color .4s}
+  body::before{content:"";position:fixed;inset:0;z-index:-2;
+    background-image:
+      url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='36' height='36'%3E%3Cpath d='M18 14v8M14 18h8' stroke='%239aa6dc' stroke-opacity='0.18' stroke-width='1'/%3E%3C/svg%3E"),
+      linear-gradient(var(--grid) 1px,transparent 1px),linear-gradient(90deg,var(--grid) 1px,transparent 1px);
+    background-size:36px 36px,36px 36px,36px 36px;background-position:18px 18px,0 0,0 0}
+  body::after{content:"";position:fixed;top:-26%;left:50%;width:920px;height:680px;transform:translateX(-50%);z-index:-1;
+    background:radial-gradient(closest-side,rgba(92,80,232,.20),transparent 70%);filter:blur(24px);pointer-events:none}
+  a{color:inherit}
+  .wrap{max-width:var(--max);margin:0 auto;padding:0 24px}
+  ::selection{background:var(--accent);color:#0a0814}
+
+  /* tilt layer for the "crooked mode" gag */
+  .tilt-layer{transition:transform 1s cubic-bezier(.6,0,.2,1);transform-origin:50% 32%}
+  body.crooked .tilt-layer{transform:rotate(-1.4deg) skewY(-.5deg) scale(.985)}
+
+  /* ---------- logo mark ---------- */
+  .mark{display:inline-block;line-height:0}
+  .mark svg{display:block}
+  .mk-frame{stroke:var(--line-2);stroke-width:1;fill:none}
+  .mk-tick{stroke:var(--tick);stroke-width:1}
+  .mk-guide{stroke:rgba(150,160,220,.30);stroke-width:1;stroke-dasharray:3 3}
+  .mk-fill{fill:var(--accent)}
+  .mk-stroke{stroke:var(--accent);stroke-width:9;fill:none;stroke-linecap:square;stroke-linejoin:miter}
+  .mk-arc{stroke:var(--accent-soft);stroke-width:3.5;fill:none}
+  .mk-draw{stroke-dasharray:170;stroke-dashoffset:170;animation:draw 1.1s .15s forwards cubic-bezier(.6,0,.2,1)}
+  .mk-pop{opacity:0;animation:pop .4s .75s forwards}
+  @keyframes draw{to{stroke-dashoffset:0}}
+  @keyframes pop{from{opacity:0;transform:scale(.4)}to{opacity:1;transform:none}}
+  .mark--replay{cursor:pointer}
+
+  /* ---------- wordmark ---------- */
+  .wordmark{font-family:var(--mono);font-weight:500;letter-spacing:.01em;text-transform:lowercase;color:var(--ink);display:inline-flex;align-items:baseline}
+  .wordmark .hy{color:var(--accent-soft)}
+
+  /* ---------- nav ---------- */
+  nav{position:sticky;top:0;z-index:50;backdrop-filter:blur(10px);background:color-mix(in srgb,var(--bg) 76%,transparent);border-bottom:1px solid var(--line)}
+  .nav-inner{display:flex;align-items:center;justify-content:space-between;height:66px}
+  .brand{display:flex;align-items:center;gap:11px}
+  .brand .wordmark{font-size:15px}
+  .nav-links{display:flex;gap:24px;font-size:13px;font-weight:500;letter-spacing:.02em;align-items:center}
+  .nav-links a{color:var(--ink-soft);text-decoration:none;transition:color .15s}
+  .nav-links a:hover{color:var(--ink)}
+  .nav-cta{font-family:var(--mono);font-size:12px;font-weight:600;border:1px solid var(--line-2);border-radius:8px;padding:8px 14px;color:var(--ink)!important}
+  .nav-cta:hover{border-color:var(--accent);color:var(--accent-soft)!important}
+  .theme{display:inline-flex;border:1px solid var(--line-2);border-radius:8px;overflow:hidden}
+  .theme button{font-family:var(--mono);font-size:11px;border:0;background:transparent;color:var(--ink-soft);padding:7px 9px;cursor:pointer;transition:.15s}
+  .theme button.on{background:var(--accent);color:#fff}
+  @media(max-width:820px){.nav-links a:not(.nav-cta){display:none}}
+
+  /* ---------- hero ---------- */
+  header.hero{text-align:center;padding:62px 0 36px}
+  .lockup{display:flex;flex-direction:column;align-items:center;gap:16px;margin-bottom:30px}
+  .lockup .wordmark{font-size:clamp(26px,5vw,38px);font-weight:500}
+  .wm-rule{width:26px;height:3px;background:var(--accent);border-radius:2px}
+  .eyebrow{font-family:var(--mono);font-size:13px;letter-spacing:.13em;color:var(--ink-soft)}
+  h1{font-family:var(--serif);font-style:italic;font-weight:500;font-size:clamp(34px,6vw,62px);line-height:1.03;letter-spacing:-.02em;margin-top:30px}
+  h1 .pop{color:var(--accent-soft);font-style:italic}
+  .lede{font-family:var(--serif);font-size:clamp(17px,2.4vw,21px);color:var(--ink);max-width:610px;margin:24px auto 0;line-height:1.5}
+  .lede .muted{color:var(--ink-soft)}
+
+  /* ---------- install widget ---------- */
+  .install{max-width:770px;margin:42px auto 0;border:1px solid var(--line-2);border-radius:14px;background:linear-gradient(180deg,var(--panel),var(--bg2));overflow:hidden;box-shadow:0 30px 70px -40px rgba(0,0,0,.85)}
+  .tabs{display:flex;gap:2px;border-bottom:1px solid var(--line);background:rgba(0,0,0,.18);overflow-x:auto}
+  .tabs button{font-family:var(--mono);font-size:12px;letter-spacing:.04em;text-transform:uppercase;font-weight:500;border:0;background:transparent;color:var(--ink-soft);padding:13px 17px;cursor:pointer;white-space:nowrap;border-bottom:2px solid transparent;margin-bottom:-1px;transition:color .15s}
+  .tabs button.on{color:var(--ink);border-bottom-color:var(--accent)}
+  .tabs button:hover{color:var(--ink)}
+  .cmd{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:19px 20px;font-family:var(--mono);font-size:14px}
+  .cmd code{color:var(--ink);white-space:nowrap;overflow:auto;scrollbar-width:none}
+  .cmd code::-webkit-scrollbar{display:none}
+  .cmd code .dim{color:var(--accent-soft)}
+  .copy{font-family:var(--mono);font-size:11px;letter-spacing:.08em;font-weight:600;border:1px solid var(--line-2);background:rgba(0,0,0,.12);color:var(--ink-soft);border-radius:7px;padding:8px 13px;cursor:pointer;transition:.15s}
+  .copy:hover{color:var(--accent-soft);border-color:var(--accent)}
+  .stat-row{display:flex;gap:34px;justify-content:center;margin:38px 0 0;flex-wrap:wrap}
+  .stat{font-family:var(--mono);font-size:12px;letter-spacing:.03em;color:var(--ink-soft)}
+  .stat b{font-family:var(--sans);font-weight:800;font-size:22px;color:var(--ink);display:block;letter-spacing:-.01em}
+
+  /* ---------- pi.dev stage: big pinned demo panel (left) + scrolling copy (right) ---------- */
+  .stage-wrap{position:relative;margin:80px 0 40px}
+  .stage-grid{display:grid;grid-template-columns:1.6fr 1fr;gap:56px;align-items:start}
+  .stage{position:sticky;top:92px;border:1px solid var(--line-2);border-radius:13px;background:var(--term);overflow:hidden;box-shadow:0 34px 90px -44px rgba(0,0,0,.95)}
+  .stage-bar{display:flex;align-items:center;gap:10px;padding:13px 18px;border-bottom:1px solid rgba(255,255,255,.08);font-family:var(--mono);font-size:11.5px;letter-spacing:.15em;text-transform:uppercase;color:#9aa0b4}
+  .live{width:8px;height:8px;border-radius:50%;background:var(--accent);animation:pulse 1.8s infinite}
+  @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(92,80,232,.7)}70%{box-shadow:0 0 0 8px transparent}100%{box-shadow:0 0 0 0 transparent}}
+  .stage-body{font-family:var(--mono);font-size:14px;line-height:2;padding:24px 22px;min-height:320px;color:#D7DAE6}
+  .stage-body>div{opacity:0;animation:fadein .32s forwards}
+  .stage-body .role{color:#8E86F4}
+  .stage-body .ok{color:#5FD08A}
+  .stage-body .you{color:#6FA0F0}
+  .stage-body .dim{color:#6C7088}
+  .cur{color:#8E86F4;animation:blink 1s steps(2,jump-none) infinite}
+  @keyframes fadein{to{opacity:1}}
+  @keyframes blink{50%{opacity:0}}
+  .stage-foot{border-top:1px solid rgba(255,255,255,.08);padding:14px 20px;font-family:var(--mono);font-size:12.5px;color:#8B90A6;min-height:46px;display:flex;align-items:center}
+  /* right column: tall editorial blocks that scroll past and drive the panel */
+  .stage-copy{display:flex;flex-direction:column}
+  .stage-block{min-height:84vh;display:flex;flex-direction:column;justify-content:center;opacity:.32;transition:opacity .45s}
+  .stage-block.active{opacity:1}
+  .stage-block:first-child{min-height:56vh;justify-content:flex-end;padding-bottom:7vh}
+  .stage-block:last-child{min-height:62vh;justify-content:flex-start;padding-top:7vh}
+  .stage-block .ix{font-family:var(--mono);font-size:12px;letter-spacing:.14em;color:var(--accent-soft);margin-bottom:12px}
+  .stage-block h3{font-family:var(--serif);font-style:italic;font-weight:500;font-size:clamp(25px,2.9vw,35px);line-height:1.08;margin-bottom:12px}
+  .stage-block p{color:var(--ink-soft);font-size:16px;line-height:1.55}
+  .stage-block code{font-family:var(--mono);font-size:.85em;color:var(--accent-soft)}
+  /* mobile: panel stacks above the (un-dimmed) copy, no pin */
+  @media(max-width:860px){.stage-grid{grid-template-columns:1fr;gap:12px}.stage{position:relative;top:0}
+    .stage-block,.stage-block:first-child,.stage-block:last-child{min-height:auto;padding:22px 0;opacity:1;justify-content:flex-start}}
+
+  /* ---------- section heads ---------- */
+  .section-head{text-align:center;margin:104px 0 8px}
+  .section-head .eyebrow{display:block;margin-bottom:14px}
+  .section-head h2{font-family:var(--serif);font-style:italic;font-weight:500;font-size:clamp(28px,4.2vw,46px)}
+  .section-head p.sub{color:var(--ink-soft);max-width:540px;margin:14px auto 0}
+
+  /* ---------- figure panels ---------- */
+  .figures{display:grid;grid-template-columns:1fr 1fr;gap:22px;margin-top:44px}
+  @media(max-width:760px){.figures{grid-template-columns:1fr}}
+  .fig{position:relative;border:1px solid var(--line);border-radius:14px;background:linear-gradient(180deg,var(--card),var(--bg2));padding:32px 28px 28px;overflow:hidden;animation:rise both;animation-timeline:view();animation-range:entry 0% cover 24%}
+  .fig::after{content:"";position:absolute;inset:0;background:radial-gradient(120% 80% at 50% 0,rgba(92,80,232,.08),transparent 60%);pointer-events:none}
+  @keyframes rise{from{opacity:0;transform:translateY(24px)}to{opacity:1;transform:none}}
+  .fig .corner{position:absolute;width:13px;height:13px;border:1.5px solid var(--accent);opacity:.6}
+  .fig .tl{top:11px;left:11px;border-right:0;border-bottom:0}.fig .tr{top:11px;right:11px;border-left:0;border-bottom:0}
+  .fig .bl{bottom:11px;left:11px;border-right:0;border-top:0}.fig .br{bottom:11px;right:11px;border-left:0;border-top:0}
+  .fig .cap{font-family:var(--mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-dim);margin-bottom:14px}
+  .fig h3{font-family:var(--serif);font-style:italic;font-weight:500;font-size:25px;margin-bottom:10px}
+  .fig p{font-size:14.5px;color:var(--ink-soft)}
+  .fig .tag{display:inline-block;font-family:var(--mono);font-size:11px;color:var(--accent-soft);border:1px solid color-mix(in srgb,var(--accent) 40%,transparent);background:color-mix(in srgb,var(--accent) 12%,transparent);border-radius:999px;padding:3px 10px;margin-top:16px}
+  .fig.span{grid-column:1/-1}
+  .toy{width:100%;height:150px;border:1px solid var(--line);border-radius:8px;margin-top:16px;background:var(--term);display:block;cursor:crosshair}
+
+  /* ---------- manipulate / crooked trigger ---------- */
+  .manip{text-align:center;margin:110px 0 0;padding:70px 24px;border:1px solid var(--line);border-radius:18px;background:linear-gradient(180deg,var(--card),var(--bg2));position:relative;overflow:hidden}
+  .manip .eyebrow{display:block;margin-bottom:14px}
+  .manip h2{font-family:var(--serif);font-style:italic;font-weight:500;font-size:clamp(26px,4vw,42px)}
+  .manip p{color:var(--ink-soft);max-width:500px;margin:14px auto 0}
+  .manip .hint{font-family:var(--mono);font-size:12px;color:var(--accent-soft);margin-top:18px}
+
+  /* ---------- team / closing / footer ---------- */
+  .roster{display:flex;flex-wrap:wrap;gap:9px;justify-content:center;max-width:920px;margin:40px auto 0}
+  .roster span{font-family:var(--mono);font-size:12.5px;color:var(--ink-soft);border:1px solid var(--line);border-radius:7px;padding:7px 12px;background:var(--bg2);transition:.15s}
+  .roster span:hover{color:var(--ink);border-color:var(--accent);transform:translateY(-2px)}
+  .platforms{margin-top:42px;border:1px solid var(--line);border-radius:14px;background:var(--bg2);padding:28px;display:flex;gap:20px;justify-content:center;flex-wrap:wrap;align-items:center}
+  .platforms span{font-family:var(--mono);font-size:13px;color:var(--ink-soft);display:flex;align-items:center;gap:9px}
+  .platforms span::before{content:"";width:7px;height:7px;border-radius:50%;background:var(--accent)}
+  .closing{text-align:center;margin:112px 0 0;padding:74px 0;border-top:1px solid var(--line);position:relative}
+  .closing::before{content:"";position:absolute;top:-30%;left:50%;width:700px;height:540px;transform:translateX(-50%);z-index:-1;background:radial-gradient(closest-side,rgba(92,80,232,.18),transparent 70%);filter:blur(24px)}
+  .closing h2{font-family:var(--serif);font-style:italic;font-weight:500;font-size:clamp(32px,5.4vw,56px)}
+  .closing p{color:var(--ink-soft);margin:16px auto 0;max-width:520px}
+  .cta{display:inline-block;font-family:var(--mono);font-size:15px;font-weight:600;background:var(--accent);color:#fff;border-radius:11px;padding:16px 28px;margin-top:28px;text-decoration:none;box-shadow:0 14px 40px -16px rgba(92,80,232,.9);transition:.15s}
+  .cta:hover{transform:translateY(-2px);box-shadow:0 18px 48px -16px rgba(92,80,232,1)}
+  .cta-note{font-family:var(--mono);font-size:12px;color:var(--ink-dim);margin-top:16px}
+  footer{border-top:1px solid var(--line);padding:30px 0;font-size:13px;color:var(--ink-soft)}
+  .foot-inner{display:flex;justify-content:space-between;flex-wrap:wrap;gap:12px;align-items:center}
+  .foot-inner a{text-decoration:none;color:var(--ink-soft)}.foot-inner a:hover{color:var(--ink)}
+
+  /* ---------- crooked callout (outside tilt-layer) ---------- */
+  .crooked-callout{position:fixed;left:18px;bottom:18px;z-index:80;display:none;align-items:center;gap:12px;font-family:var(--mono);font-size:12px;color:var(--ink);background:var(--panel);border:1px solid var(--line-2);border-radius:10px;padding:11px 13px;box-shadow:0 18px 50px -22px #000}
+  body.crooked .crooked-callout{display:flex}
+  .crooked-callout b{color:var(--accent-soft)}
+  .crooked-callout .dot{width:7px;height:7px;border-radius:50%;background:var(--accent);animation:pulse 1.8s infinite}
+  .crooked-callout button{font:inherit;font-weight:600;color:var(--ink);background:transparent;border:1px solid var(--line-2);border-radius:7px;padding:5px 11px;cursor:pointer}
+  .crooked-callout button:hover{border-color:var(--accent);color:var(--accent-soft)}
+
+  @media(prefers-reduced-motion:reduce){*{animation:none!important}.tilt-layer{transition:none}}
+</style>
+</head>
+<body>
+<div class="tilt-layer">
+
+<nav><div class="wrap nav-inner">
+  <div class="brand"><span class="mark" data-mark="sm"></span> <span class="wordmark">naksha<span class="hy">-</span>studio</span></div>
+  <div class="nav-links">
+    <a href="#stage">How it works</a>
+    <a href="#commands">Commands</a>
+    <a href="#team">The team</a>
+    <div class="theme" id="theme">
+      <button data-t="light" title="Light">☀</button>
+      <button data-t="auto" title="Auto">A</button>
+      <button data-t="dark" class="on" title="Dark">☾</button>
+    </div>
+    <a href="https://github.com/Adityaraj0421/naksha-studio" class="nav-cta">Get naksha</a>
+  </div>
+</div></nav>
+
+<header class="hero"><div class="wrap">
+  <div class="lockup">
+    <span class="mark mark--replay" id="heromark" data-mark="lg" title="click to replay"></span>
+    <span class="wordmark">naksha<span class="hy">-</span>studio</span>
+    <span class="wm-rule"></span>
+    <p class="eyebrow">A virtual design agency in your terminal.</p>
+  </div>
+  <h1>There are many AI design tools<br>but this one is a <span class="pop">studio</span></h1>
+  <p class="lede">naksha assembles 26 specialist roles — a creative director, UX designer, UI designer, content designer, and more — to take a screen from brief to built. <span class="muted">You run one command. The whole agency shows up.</span></p>
+
+  <div class="install" id="install">
+    <div class="tabs" id="tabs">
+      <button class="on" data-cmd="claude">Claude Code</button>
+      <button data-cmd="cursor">Cursor</button>
+      <button data-cmd="windsurf">Windsurf</button>
+      <button data-cmd="gemini">Gemini CLI</button>
+      <button data-cmd="copilot">Copilot</button>
+    </div>
+    <div class="cmd">
+      <code id="cmdtext"><span class="dim">/plugin marketplace add</span> Adityaraj0421/naksha-studio</code>
+      <button class="copy" id="copy">[ COPY ]</button>
+    </div>
+  </div>
+
+  <div class="stat-row">
+    <span class="stat"><b>26</b> specialist roles</span>
+    <span class="stat"><b>63</b> commands</span>
+    <span class="stat"><b>15k+</b> lines of design knowledge</span>
+    <span class="stat"><b>5</b> platforms</span>
+  </div>
+</div></header>
+
+<!-- pi.dev stage: pinned demo panel (left) + scrolling editorial copy (right) -->
+<section class="stage-wrap" id="stage"><div class="wrap stage-grid">
+  <div class="stage">
+    <div class="stage-bar"><span class="live"></span> <span id="stagecap">NAKSHA — RUN THE TEAM</span></div>
+    <div class="stage-body" id="stagebody"></div>
+    <div class="stage-foot" id="stagefoot"></div>
+  </div>
+  <div class="stage-copy" id="stagecopy">
+    <div class="stage-block" data-step="0">
+      <div class="ix">01 — /design</div>
+      <h3>One command, a whole studio</h3>
+      <p>Type <code>/design</code> and naksha assembles the right specialists for the job — no prompt-engineering one persona into doing everyone's work.</p>
+    </div>
+    <div class="stage-block" data-step="1">
+      <div class="ix">02 — the team</div>
+      <h3>Each role makes one real call</h3>
+      <p>The content designer owns the words, the system lead owns the tokens, accessibility owns the contrast. You see who decided what, and why.</p>
+    </div>
+    <div class="stage-block" data-step="2">
+      <div class="ix">03 — /design-reel</div>
+      <h3>Then it films itself</h3>
+      <p><code>/design-reel</code> renders the run into a share-able 9:16 + 16:9 video — the team redesigning your screen, captioned, live.</p>
+    </div>
+    <div class="stage-block" data-step="3">
+      <div class="ix">04 — memory</div>
+      <h3>It keeps your project in mind</h3>
+      <p>Constraints, tokens, brand voice, and browser research persist and seed every command you run next.</p>
+    </div>
+  </div>
+</div></section>
+
+<!-- figure panels -->
+<section id="commands"><div class="wrap">
+  <div class="section-head">
+    <span class="eyebrow">What's in the box</span>
+    <h2>Primitives, not prompts</h2>
+    <p class="sub">63 commands across the whole design surface — each a real workflow, not a canned reply.</p>
+  </div>
+  <div class="figures">
+    <div class="fig">
+      <span class="corner tl"></span><span class="corner tr"></span><span class="corner bl"></span><span class="corner br"></span>
+      <div class="cap">Fig. 01 — /design</div><h3>Brief to built</h3>
+      <p>The full workflow: the right roles assemble, design the screen, and hand you production HTML you can ship.</p>
+      <span class="tag">/design Build a pricing page</span>
+    </div>
+    <div class="fig">
+      <span class="corner tl"></span><span class="corner tr"></span><span class="corner bl"></span><span class="corner br"></span>
+      <div class="cap">Fig. 02 — /design-reel</div><h3>Watch the team work</h3>
+      <p>Renders a <code>/design</code> run into a vertical + landscape video. Post-ready, captioned, with an honest end-card.</p>
+      <span class="tag">/design-reel · 9:16 + 16:9</span>
+    </div>
+    <div class="fig">
+      <span class="corner tl"></span><span class="corner tr"></span><span class="corner bl"></span><span class="corner br"></span>
+      <div class="cap">Fig. 03 — Project memory</div><h3>It remembers your project</h3>
+      <p>Constraints, tokens, brand, and browser research persist and seed every future command automatically.</p>
+      <span class="tag">/naksha-remember · /naksha-browse</span>
+    </div>
+    <div class="fig">
+      <span class="corner tl"></span><span class="corner tr"></span><span class="corner bl"></span><span class="corner br"></span>
+      <div class="cap">Fig. 04 — Figma &amp; handoff</div><h3>Out to the tools you use</h3>
+      <p>Figma to code, code to Figma, responsive variants, design systems, and developer handoff docs.</p>
+      <span class="tag">/figma · /design-system · /design-handoff</span>
+    </div>
+    <div class="fig span">
+      <span class="corner tl"></span><span class="corner tr"></span><span class="corner bl"></span><span class="corner br"></span>
+      <div class="cap">Fig. 05 — Review &amp; audit</div><h3>And it critiques its own work</h3>
+      <p>Design review, UX audits against a brief, accessibility scoring, and brand-kit generation — the same agency that builds it also grades it.</p>
+      <span class="tag">/design-review · /ux-audit · /accessibility-audit · /brand-kit</span>
+    </div>
+    <div class="fig span">
+      <span class="corner tl"></span><span class="corner tr"></span><span class="corner bl"></span><span class="corner br"></span>
+      <div class="cap">Fig. 06 — Live</div><h3>Move your cursor. It's a blueprint.</h3>
+      <p>Everything here is drawn, not pasted — including this. naksha thinks in grids, ticks, and guides.</p>
+      <canvas class="toy" id="toy"></canvas>
+    </div>
+  </div>
+</div></section>
+
+<!-- manipulate / crooked trigger -->
+<section class="manip" id="manip"><div class="wrap">
+  <span class="eyebrow">Live demo</span>
+  <h2>It can even redesign this page</h2>
+  <p>naksha rewrites interfaces in place. Scroll here and watch it take a crooked pass at its own site.</p>
+  <div class="hint">▎ crooked mode engaging…</div>
+</div></section>
+
+<!-- the team -->
+<section id="team"><div class="wrap">
+  <div class="section-head">
+    <span class="eyebrow">26 specialists on call</span>
+    <h2>The whole agency, assembled per task</h2>
+    <p class="sub">naksha staffs every role you'd hire a design agency for — and pulls in exactly the ones your task needs.</p>
+  </div>
+  <div class="roster">
+    <span>Creative Director</span><span>Art Director</span><span>UX Designer</span><span>UX Researcher</span><span>UI Designer</span><span>Visual Designer</span><span>Interaction Designer</span><span>Product Designer</span><span>Content Designer</span><span>UX Copywriter</span><span>Design System Lead</span><span>Design Technologist</span><span>Figma Expert</span><span>Prototyper</span><span>Data Viz Designer</span><span>Motion Designer</span><span>Illustrator</span><span>Brand Strategist</span><span>Email Designer</span><span>Social Designer</span><span>Presentation Designer</span><span>Video Designer</span><span>Conversational Designer</span><span>Spatial Designer</span><span>Accessibility Specialist</span><span>Compliance Reviewer</span>
+  </div>
+  <div class="platforms">
+    <span>Claude Code</span><span>Cursor</span><span>Windsurf</span><span>Gemini CLI</span><span>Copilot</span>
+  </div>
+</div></section>
+
+<section class="closing"><div class="wrap">
+  <span class="mark mark--replay" data-mark="lg" style="margin-bottom:26px"></span>
+  <h2>Your turn to run the agency</h2>
+  <p>26 roles design your screen, live. One command, in the terminal you already have open.</p>
+  <a class="cta" href="https://github.com/Adityaraj0421/naksha-studio">Get naksha →</a>
+  <div class="cta-note">MIT licensed · free · works where you already code</div>
+</div></section>
+
+<footer><div class="wrap foot-inner">
+  <span class="wordmark" style="font-size:13px">naksha<span class="hy">-</span>studio</span>
+  <span><a href="https://github.com/Adityaraj0421/naksha-studio">GitHub</a> · <a href="https://github.com/Adityaraj0421/naksha-studio/blob/main/CHANGELOG.md">Changelog</a> · <a href="#commands">Commands</a> · MIT</span>
+</div></footer>
+
+</div><!-- /tilt-layer -->
+
+<aside class="crooked-callout">
+  <span class="dot"></span> <b>Crooked mode: ON</b>
+  <button id="revert">Revert</button>
+</aside>
+
+<script>
+  // ---- blueprint logo mark ----
+  function markSVG(size,animate){
+    const c = animate ? 'mk-draw' : '';
+    return `<svg width="${size}" height="${size}" viewBox="0 0 96 96" fill="none">
+      <path class="mk-tick" d="M20 12v8M12 20h8 M76 12v8M84 20h-8 M20 84v-8M12 76h8 M76 84v-8M84 76h-8"/>
+      <rect class="mk-frame" x="20" y="20" width="56" height="56" rx="1"/>
+      <path class="mk-guide" d="M48 20v56 M20 48h56"/>
+      <polyline class="mk-stroke ${c}" points="33,32 49,48 33,64"/>
+      <path class="mk-arc ${c}" d="M55 29 A16 16 0 0 1 71 45"/>
+      <rect class="mk-fill ${animate?'mk-pop':''}" x="58" y="58" width="12" height="12" rx="1"/>
+    </svg>`;
+  }
+  document.querySelectorAll('.mark').forEach(m=>{
+    const big = m.dataset.mark==='lg';
+    m.innerHTML = markSVG(big?76:28, big);
+    if(m.classList.contains('mark--replay'))
+      m.addEventListener('click',()=>{ m.innerHTML=markSVG(76,true); });
+  });
+
+  // ---- theme toggle (light / auto / dark) ----
+  const themeBox=document.getElementById('theme'), mq=matchMedia('(prefers-color-scheme: light)');
+  function applyTheme(t){
+    document.documentElement.dataset.theme = (t==='auto') ? (mq.matches?'light':'dark') : t;
+    [...themeBox.children].forEach(b=>b.classList.toggle('on', b.dataset.t===t));
+  }
+  themeBox.addEventListener('click',e=>{const b=e.target.closest('button'); if(b) applyTheme(b.dataset.t);});
+
+  // ---- install command per platform ----
+  const CMDS={
+    claude:'<span class="dim">/plugin marketplace add</span> Adityaraj0421/naksha-studio',
+    cursor:'<span class="dim">git clone</span> github.com/Adityaraj0421/naksha-studio <span class="dim">~/.naksha</span>',
+    windsurf:'<span class="dim">git clone</span> github.com/Adityaraj0421/naksha-studio <span class="dim">~/.naksha</span>',
+    gemini:'<span class="dim">git clone</span> github.com/Adityaraj0421/naksha-studio <span class="dim">~/.naksha</span>',
+    copilot:'<span class="dim">git clone</span> github.com/Adityaraj0421/naksha-studio <span class="dim">~/.naksha</span>',
+  };
+  const tabs=document.getElementById('tabs'), cmd=document.getElementById('cmdtext');
+  tabs.addEventListener('click',e=>{const b=e.target.closest('button'); if(!b)return;
+    [...tabs.children].forEach(x=>x.classList.toggle('on',x===b)); cmd.innerHTML=CMDS[b.dataset.cmd];});
+  document.getElementById('copy').addEventListener('click',async e=>{
+    try{await navigator.clipboard.writeText(cmd.textContent);e.target.textContent='[ COPIED ]';setTimeout(()=>e.target.textContent='[ COPY ]',1200);}
+    catch{e.target.textContent='[ ⌘C ]';}
+  });
+
+  // ---- pinned demo panel (left) driven by the scrolling copy blocks (right) ----
+  const STEPS=[
+    {cap:'NAKSHA — RUN THE TEAM', foot:'naksha designs the screen, role by role.',
+     lines:['<span class="you">you ›</span> /design a pricing page',
+            '<span class="dim">spinning up the agency…</span>',
+            '<span class="role">Creative Director</span> anchors on the Pro tier.',
+            '<span class="role">UX Designer</span> lays out 3 tiers + annual toggle.',
+            '<span class="role">UI Designer</span> applies tokens, type scale, spacing.',
+            '<span class="ok">✓</span> design-output.html ready']},
+    {cap:'NAKSHA — EVERY ROLE WEIGHS IN', foot:'every specialist makes one real decision.',
+     lines:['<span class="dim">› the rest of the team weighs in</span>',
+            '<span class="role">Content Designer</span> "Save 20%" beats "−20%".',
+            '<span class="role">Design System Lead</span> one accent, 8px grid.',
+            '<span class="role">Accessibility</span> contrast AA, 44px targets.',
+            '<span class="ok">✓</span> 5 roles · 1 screen · agreed']},
+    {cap:'NAKSHA — WATCH IT BACK', foot:'/design-reel turns the run into a video.',
+     lines:['<span class="you">you ›</span> /design-reel',
+            '<span class="dim">extracting role beats…</span>',
+            '<span class="role">naksha</span> 5 beats · after-only mode',
+            '<span class="dim">rendering 9:16 + 16:9…</span>',
+            '<span class="ok">✓</span> reel-9x16.mp4 · reel-16x9.mp4']},
+    {cap:'NAKSHA — IT REMEMBERS', foot:'project memory seeds your next command.',
+     lines:['<span class="you">you ›</span> /naksha-remember grid 8px, brand #5C50E8',
+            '<span class="ok">✓</span> saved to project memory',
+            '<span class="dim">next /design uses it automatically</span>',
+            '<span class="role">naksha</span> remembers, so you don\'t repeat yourself.']},
+  ];
+  const stageBody=document.getElementById('stagebody'), cap=document.getElementById('stagecap'),
+        stageFoot=document.getElementById('stagefoot'), blocks=[...document.querySelectorAll('.stage-block')];
+  let curStep=-1;
+  function renderStage(i){
+    if(i===curStep) return; curStep=i;
+    const s=STEPS[i];
+    cap.textContent=s.cap;
+    stageFoot.textContent=s.foot;
+    stageBody.innerHTML=s.lines.map((l,k)=>`<div style="animation-delay:${k*0.1}s">${l}</div>`).join('')
+      + `<div style="animation-delay:${s.lines.length*0.1}s"><span class="cur">▋</span></div>`;
+    blocks.forEach((b,k)=>b.classList.toggle('active',k===i));
+  }
+  renderStage(0);
+  // each copy block is ~one viewport tall; whichever crosses center is active and drives the panel
+  const sio=new IntersectionObserver(es=>{es.forEach(en=>{ if(en.isIntersecting) renderStage(+en.target.dataset.step); });},
+    {rootMargin:'-45% 0px -45% 0px'});
+  blocks.forEach(b=>sio.observe(b));
+
+  // ---- crooked mode: naksha tilts its own page ----
+  const cio=new IntersectionObserver(es=>{es.forEach(en=>{
+    if(en.isIntersecting && !document.body.classList.contains('reverted')) document.body.classList.add('crooked');
+  });},{threshold:.5});
+  cio.observe(document.getElementById('manip'));
+  document.getElementById('revert').addEventListener('click',()=>{
+    document.body.classList.remove('crooked'); document.body.classList.add('reverted');
+  });
+
+  // ---- Fig.06: interactive blueprint canvas (cursor-reactive grid) ----
+  const cv=document.getElementById('toy'), ctx=cv.getContext('2d');
+  let mx=-999,my=-999;
+  function size(){const r=cv.getBoundingClientRect();cv.width=r.width*devicePixelRatio;cv.height=r.height*devicePixelRatio;ctx.setTransform(devicePixelRatio,0,0,devicePixelRatio,0,0);}
+  size(); addEventListener('resize',size);
+  cv.addEventListener('pointermove',e=>{const r=cv.getBoundingClientRect();mx=e.clientX-r.left;my=e.clientY-r.top;});
+  cv.addEventListener('pointerleave',()=>{mx=my=-999;});
+  function tick(){
+    const w=cv.width/devicePixelRatio,h=cv.height/devicePixelRatio,g=22;
+    ctx.clearRect(0,0,w,h);
+    for(let x=g;x<w;x+=g)for(let y=g;y<h;y+=g){
+      const d=Math.hypot(x-mx,y-my),k=Math.max(0,1-d/120);
+      ctx.fillStyle=`rgba(142,134,244,${.10+.85*k})`;
+      const s=1+2.4*k; ctx.fillRect(x-s/2,y-s/2,s,s);
+    }
+    if(mx>0){ctx.strokeStyle='rgba(142,134,244,.5)';ctx.lineWidth=1;
+      ctx.beginPath();ctx.moveTo(mx-9,my);ctx.lineTo(mx+9,my);ctx.moveTo(mx,my-9);ctx.lineTo(mx,my+9);ctx.stroke();}
+    requestAnimationFrame(tick);
+  }
+  tick();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Single-file marketing site (site/index.html) in the brand identity, pi.dev-style: pinned demo panel + scrolling editorial copy (1.6fr 1fr), blueprint logo, crooked-mode gag, theme toggle, interactive canvas. No framework, no build. Adds a Pages workflow publishing site/ on push to main; excludes site/ from design-lint. All 5 gates pass; rendered headless with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public landing page with theme switching, an install command selector, scroll-driven demo panels, and interactive visual elements.
  * Added GitHub Pages deployment so the site can be published automatically from the repository.

* **Chores**
  * Updated lint ignore settings to exclude the site content from design checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->