### PR TITLE
feat(site): UI/UX fixes + aesthetic materiality/motion pass

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -46,6 +46,17 @@
   section[id],#install{scroll-margin-top:84px}
   /* one visible focus ring for every control (none existed before) */
   a:focus-visible,button:focus-visible,[tabindex]:focus-visible{outline:2px solid var(--accent-soft);outline-offset:3px;border-radius:5px}
+  /* a11y: screen-reader-only utility + skip link */
+  .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+  .skip{position:fixed;top:10px;left:10px;z-index:200;transform:translateY(-180%);background:var(--accent);color:#fff;font-family:var(--mono);font-size:13px;padding:11px 16px;border-radius:8px;text-decoration:none;transition:transform .18s}
+  .skip:focus{transform:translateY(0)}
+  /* touch: guarantee ≥44px hit areas on touch devices (skill §2) */
+  @media(pointer:coarse){
+    .theme button{min-height:44px}
+    .copy{min-height:44px}
+    .nav-cta{min-height:44px;display:inline-flex;align-items:center}
+    .foot-inner a{display:inline-flex;align-items:center;min-height:44px;padding:0 4px}
+  }
   body{font-family:var(--sans);color:var(--ink);background:var(--bg);line-height:1.5;-webkit-font-smoothing:antialiased;overflow-x:hidden;transition:background .4s,color .4s}
   body::before{content:"";position:fixed;inset:0;z-index:-2;
     background-image:
@@ -152,9 +163,15 @@
   .stage-block h3{font-family:var(--serif);font-style:italic;font-weight:500;font-size:clamp(25px,2.9vw,35px);line-height:1.08;margin-bottom:12px}
   .stage-block p{color:var(--ink-soft);font-size:16px;line-height:1.55}
   .stage-block code{font-family:var(--mono);font-size:.85em;color:var(--accent-soft)}
-  /* mobile: panel stacks above the (un-dimmed) copy, no pin */
-  @media(max-width:860px){.stage-grid{grid-template-columns:1fr;gap:12px}.stage{position:relative;top:0}
-    .stage-block,.stage-block:first-child,.stage-block:last-child{min-height:auto;padding:22px 0;opacity:1;justify-content:flex-start}}
+  /* mobile: the big panel can't pin on a phone — hide it, give each block its own inline terminal */
+  .stage-mini{display:none}
+  @media(max-width:860px){.stage-grid{grid-template-columns:1fr;gap:0}.stage{display:none}
+    .stage-block,.stage-block:first-child,.stage-block:last-child{min-height:auto;padding:30px 0;opacity:1;justify-content:flex-start}
+    .stage-mini{display:block;margin-top:18px;border:1px solid var(--line-2);border-radius:12px;background:var(--term);overflow:hidden}
+    .sm-bar{display:flex;align-items:center;gap:8px;padding:10px 14px;border-bottom:1px solid rgba(255,255,255,.08);font-family:var(--mono);font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:#9aa0b4}
+    .sm-body{font-family:var(--mono);font-size:12.5px;line-height:1.85;padding:14px;color:#D7DAE6}
+    .sm-body .role{color:#8E86F4}.sm-body .ok{color:#5FD08A}.sm-body .you{color:#6FA0F0}.sm-body .dim{color:#6C7088}
+    .sm-foot{border-top:1px solid rgba(255,255,255,.08);padding:11px 14px;font-family:var(--mono);font-size:11.5px;color:#8B90A6}}
 
   /* ---------- section heads ---------- */
   .section-head{text-align:center;margin:104px 0 8px}
@@ -215,7 +232,7 @@
 
   /* ---------- before/after showcase ---------- */
   .showcase{margin:34px auto 0;max-width:430px}
-  .ba{position:relative;width:100%;border:1px solid var(--line-2);border-radius:16px;overflow:hidden;aspect-ratio:900/1340;box-shadow:0 34px 90px -50px rgba(0,0,0,.95);touch-action:none;background:var(--term)}
+  .ba{position:relative;width:100%;border:1px solid var(--line-2);border-radius:16px;overflow:hidden;aspect-ratio:900/1340;box-shadow:0 34px 90px -50px rgba(0,0,0,.95);touch-action:pan-y;background:var(--term)}
   .ba img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;object-position:top;display:block;user-select:none;-webkit-user-drag:none}
   .ba .after{clip-path:inset(0 0 0 var(--x,52%))}
   .ba-div{position:absolute;top:0;bottom:0;left:var(--x,52%);width:2px;background:var(--accent-soft);transform:translateX(-1px);pointer-events:none;box-shadow:0 0 16px var(--accent)}
@@ -262,6 +279,7 @@
 </style>
 </head>
 <body>
+<a class="skip" href="#install">Skip to install</a>
 <div class="tilt-layer">
 
 <nav><div class="wrap nav-inner">
@@ -312,7 +330,7 @@
 </div></header>
 
 <!-- pi.dev stage: pinned demo panel (left) + scrolling editorial copy (right) -->
-<section class="stage-wrap" id="stage"><div class="wrap stage-grid">
+<section class="stage-wrap" id="stage"><h2 class="sr-only">How it works — naksha runs the team</h2><div class="wrap stage-grid">
   <div class="stage">
     <div class="stage-bar"><span class="live"></span> <span id="stagecap">NAKSHA — RUN THE TEAM</span></div>
     <div class="stage-body" id="stagebody"></div>
@@ -351,8 +369,8 @@
   </div>
   <div class="showcase">
     <div class="ba" id="ba" style="--x:52%">
-      <img class="before" src="before.png" alt="Raw, unstyled Account Settings form — the starting brief" draggable="false">
-      <img class="after" src="after.png" alt="naksha's redesigned dark Account Settings screen — the built result" draggable="false">
+      <img class="before" src="before.png" alt="Raw, unstyled Account Settings form — the starting brief" draggable="false" loading="lazy" decoding="async">
+      <img class="after" src="after.png" alt="naksha's redesigned dark Account Settings screen — the built result" draggable="false" loading="lazy" decoding="async">
       <div class="ba-div"></div>
       <div class="ba-grip">⇆</div>
       <span class="ba-tag bl">BEFORE</span>
@@ -599,11 +617,22 @@
       + `<div style="animation-delay:${s.lines.length*0.1}s"><span class="cur">▋</span></div>`;
     blocks.forEach((b,k)=>b.classList.toggle('active',k===i));
   }
-  renderStage(0);
-  // each copy block is ~one viewport tall; whichever crosses center is active and drives the panel
-  const sio=new IntersectionObserver(es=>{es.forEach(en=>{ if(en.isIntersecting) renderStage(+en.target.dataset.step); });},
-    {rootMargin:'-45% 0px -45% 0px'});
-  blocks.forEach(b=>sio.observe(b));
+  if(matchMedia('(max-width:860px)').matches){
+    // phone: the shared panel can't pin, so render each step's terminal inline under its own block
+    blocks.forEach((b,i)=>{ const s=STEPS[i]; if(!s) return;
+      const t=document.createElement('div'); t.className='stage-mini';
+      t.innerHTML=`<div class="sm-bar"><span class="live"></span> ${s.cap}</div>`+
+        `<div class="sm-body">${s.lines.map(l=>`<div>${l}</div>`).join('')}</div>`+
+        `<div class="sm-foot">${s.foot}</div>`;
+      b.appendChild(t);
+    });
+  } else {
+    renderStage(0);
+    // each copy block is ~one viewport tall; whichever crosses center is active and drives the panel
+    const sio=new IntersectionObserver(es=>{es.forEach(en=>{ if(en.isIntersecting) renderStage(+en.target.dataset.step); });},
+      {rootMargin:'-45% 0px -45% 0px'});
+    blocks.forEach(b=>sio.observe(b));
+  }
 
   // ---- crooked mode: naksha tilts its own page ----
   const reduceMotion=matchMedia('(prefers-reduced-motion: reduce)').matches;

--- a/site/index.html
+++ b/site/index.html
@@ -30,6 +30,9 @@
     --ink:#F3F4FA; --ink-soft:#9094A6; --ink-dim:#777E9C;
     --accent:#5C50E8; --accent-soft:#8E86F4; --accent-deep:#3A30B8;
     --grid:rgba(150,160,220,.05); --tick:rgba(150,160,220,.16);
+    --ease:cubic-bezier(.16,1,.3,1);
+    --edge:inset 0 1px 0 rgba(255,255,255,.06);                 /* glass top highlight */
+    --lift:0 28px 64px -38px rgba(20,16,58,.92);                /* elevation, tinted to iris-navy not pure black */
     --serif:"Newsreader",Georgia,serif; --mono:"JetBrains Mono",ui-monospace,monospace; --sans:"Inter",system-ui,sans-serif;
     --max:1120px;
   }
@@ -63,8 +66,12 @@
       url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='36' height='36'%3E%3Cpath d='M18 14v8M14 18h8' stroke='%239aa6dc' stroke-opacity='0.18' stroke-width='1'/%3E%3C/svg%3E"),
       linear-gradient(var(--grid) 1px,transparent 1px),linear-gradient(90deg,var(--grid) 1px,transparent 1px);
     background-size:36px 36px,36px 36px,36px 36px;background-position:18px 18px,0 0,0 0}
-  body::after{content:"";position:fixed;top:-26%;left:50%;width:920px;height:680px;transform:translateX(-50%);z-index:-1;
-    background:radial-gradient(closest-side,rgba(92,80,232,.20),transparent 70%);filter:blur(24px);pointer-events:none}
+  body::after{content:"";position:fixed;top:-28%;left:50%;width:1040px;height:760px;transform:translateX(-50%);z-index:-1;
+    background:radial-gradient(closest-side,rgba(92,80,232,.13),transparent 72%);filter:blur(42px);pointer-events:none}
+  /* film grain: fixed, painted once, never on a scrolling container (perf) */
+  .grain{position:fixed;inset:0;z-index:60;pointer-events:none;opacity:.035;
+    background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+  html[data-theme="light"] .grain{opacity:.02;mix-blend-mode:multiply}
   a{color:inherit}
   .wrap{max-width:var(--max);margin:0 auto;padding:0 24px}
   ::selection{background:var(--accent);color:#0a0814}
@@ -100,8 +107,9 @@
   .nav-links{display:flex;gap:24px;font-size:13px;font-weight:500;letter-spacing:.02em;align-items:center}
   .nav-links a{color:var(--ink-soft);text-decoration:none;transition:color .15s}
   .nav-links a:hover{color:var(--ink)}
-  .nav-cta{font-family:var(--mono);font-size:12px;font-weight:600;border:1px solid var(--line-2);border-radius:8px;padding:8px 14px;color:var(--ink)!important}
-  .nav-cta:hover{border-color:var(--accent);color:var(--accent-soft)!important}
+  .nav-cta{font-family:var(--mono);font-size:12px;font-weight:600;border:1px solid var(--line-2);border-radius:8px;padding:8px 14px;color:var(--ink)!important;box-shadow:var(--edge);transition:border-color .25s var(--ease),color .25s var(--ease),background .25s var(--ease)}
+  .nav-cta:hover{border-color:var(--accent);color:var(--accent-soft)!important;background:color-mix(in srgb,var(--accent) 9%,transparent)}
+  .nav-cta:active{transform:translateY(1px)}
   .theme{display:inline-flex;border:1px solid var(--line-2);border-radius:8px;overflow:hidden}
   .theme button{font-family:var(--mono);font-size:11px;border:0;background:transparent;color:var(--ink-soft);padding:7px 9px;cursor:pointer;transition:.15s}
   .theme button.on{background:var(--accent);color:#fff}
@@ -119,7 +127,7 @@
   .lede .muted{color:var(--ink-soft)}
 
   /* ---------- install widget ---------- */
-  .install{max-width:770px;margin:42px auto 0;border:1px solid var(--line-2);border-radius:14px;background:linear-gradient(180deg,var(--panel),var(--bg2));overflow:hidden;box-shadow:0 30px 70px -40px rgba(0,0,0,.85)}
+  .install{max-width:770px;margin:42px auto 0;border:1px solid var(--line-2);border-radius:14px;background:linear-gradient(180deg,var(--panel),var(--bg2));overflow:hidden;box-shadow:var(--edge),var(--lift)}
   .tabs{display:flex;gap:2px;border-bottom:1px solid var(--line);background:rgba(0,0,0,.18);overflow-x:auto;scrollbar-width:none}
   .tabs::-webkit-scrollbar{display:none}
   .tabs button{font-family:var(--mono);font-size:12px;letter-spacing:.04em;text-transform:uppercase;font-weight:500;border:0;background:transparent;color:var(--ink-soft);padding:13px 17px;cursor:pointer;white-space:nowrap;border-bottom:2px solid transparent;margin-bottom:-1px;transition:color .15s}
@@ -131,6 +139,7 @@
   .cmd code .dim{color:var(--accent-soft)}
   .copy{font-family:var(--mono);font-size:11px;letter-spacing:.08em;font-weight:600;border:1px solid var(--line-2);background:rgba(0,0,0,.12);color:var(--ink-soft);border-radius:7px;padding:8px 13px;cursor:pointer;transition:.15s}
   .copy:hover{color:var(--accent-soft);border-color:var(--accent)}
+  .copy:active{transform:scale(.96)}
   .copy.copied{color:#5FD08A;border-color:#5FD08A}
   .stat-row{display:flex;gap:34px;justify-content:center;margin:38px 0 0;flex-wrap:wrap}
   .stat{font-family:var(--mono);font-size:12px;letter-spacing:.03em;color:var(--ink-soft)}
@@ -139,7 +148,7 @@
   /* ---------- pi.dev stage: big pinned demo panel (left) + scrolling copy (right) ---------- */
   .stage-wrap{position:relative;margin:80px 0 40px}
   .stage-grid{display:grid;grid-template-columns:1.6fr 1fr;gap:56px;align-items:start}
-  .stage{position:sticky;top:92px;border:1px solid var(--line-2);border-radius:13px;background:var(--term);overflow:hidden;box-shadow:0 34px 90px -44px rgba(0,0,0,.95)}
+  .stage{position:sticky;top:92px;border:1px solid var(--line-2);border-radius:13px;background:var(--term);overflow:hidden;box-shadow:inset 0 1px 0 rgba(255,255,255,.05),0 34px 90px -44px rgba(16,12,46,.95)}
   .stage-bar{display:flex;align-items:center;gap:10px;padding:13px 18px;border-bottom:1px solid rgba(255,255,255,.08);font-family:var(--mono);font-size:11.5px;letter-spacing:.15em;text-transform:uppercase;color:#9aa0b4}
   .live{width:8px;height:8px;border-radius:50%;background:var(--accent);animation:pulse 1.8s infinite}
   @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(92,80,232,.7)}70%{box-shadow:0 0 0 8px transparent}100%{box-shadow:0 0 0 0 transparent}}
@@ -182,8 +191,10 @@
   /* ---------- figure panels ---------- */
   .figures{display:grid;grid-template-columns:1fr 1fr;gap:22px;margin-top:44px}
   @media(max-width:760px){.figures{grid-template-columns:1fr}}
-  .fig{position:relative;border:1px solid var(--line);border-radius:14px;background:linear-gradient(180deg,var(--card),var(--bg2));padding:32px 28px 28px;overflow:hidden;animation:rise both;animation-timeline:view();animation-range:entry 0% cover 24%}
-  .fig::after{content:"";position:absolute;inset:0;background:radial-gradient(120% 80% at 50% 0,rgba(92,80,232,.08),transparent 60%);pointer-events:none}
+  .fig{position:relative;border:1px solid var(--line);border-radius:14px;background:linear-gradient(180deg,var(--card),var(--bg2));padding:32px 28px 28px;overflow:hidden;box-shadow:var(--edge);transition:border-color .3s var(--ease),transform .3s var(--ease);animation:rise both;animation-timeline:view();animation-range:entry 0% cover 24%}
+  .fig:hover{border-color:var(--line-2);transform:translateY(-2px)}
+  /* cursor spotlight: top-center glow at rest, follows the pointer on hover */
+  .fig::after{content:"";position:absolute;inset:0;pointer-events:none;transition:background .25s var(--ease);background:radial-gradient(240px circle at var(--mx,50%) var(--my,0%),rgba(142,134,244,.13),transparent 55%)}
   @keyframes rise{from{opacity:0;transform:translateY(24px)}to{opacity:1;transform:none}}
   .fig .corner{position:absolute;width:13px;height:13px;border:1.5px solid var(--accent);opacity:.6}
   .fig .tl{top:11px;left:11px;border-right:0;border-bottom:0}.fig .tr{top:11px;right:11px;border-left:0;border-bottom:0}
@@ -196,7 +207,7 @@
   .toy{width:100%;height:150px;border:1px solid var(--line);border-radius:8px;margin-top:16px;background:var(--term);display:block;cursor:crosshair}
 
   /* ---------- manipulate / crooked trigger ---------- */
-  .manip{text-align:center;margin:110px 0 0;padding:70px 24px;border:1px solid var(--line);border-radius:18px;background:linear-gradient(180deg,var(--card),var(--bg2));position:relative;overflow:hidden}
+  .manip{text-align:center;margin:110px 0 0;padding:70px 24px;border:1px solid var(--line);border-radius:18px;background:linear-gradient(180deg,var(--card),var(--bg2));position:relative;overflow:hidden;box-shadow:var(--edge),var(--lift)}
   .manip .eyebrow{display:block;margin-bottom:14px}
   .manip h2{font-family:var(--serif);font-style:italic;font-weight:500;font-size:clamp(26px,4vw,42px)}
   .manip p{color:var(--ink-soft);max-width:500px;margin:14px auto 0}
@@ -213,8 +224,9 @@
   .closing::before{content:"";position:absolute;top:-30%;left:50%;width:700px;height:540px;transform:translateX(-50%);z-index:-1;background:radial-gradient(closest-side,rgba(92,80,232,.18),transparent 70%);filter:blur(24px)}
   .closing h2{font-family:var(--serif);font-style:italic;font-weight:500;font-size:clamp(32px,5.4vw,56px)}
   .closing p{color:var(--ink-soft);margin:16px auto 0;max-width:520px}
-  .cta{display:inline-block;font-family:var(--mono);font-size:15px;font-weight:600;background:var(--accent);color:#fff;border-radius:11px;padding:16px 28px;margin-top:28px;text-decoration:none;box-shadow:0 14px 40px -16px rgba(92,80,232,.9);transition:.15s}
-  .cta:hover{transform:translateY(-2px);box-shadow:0 18px 48px -16px rgba(92,80,232,1)}
+  .cta{display:inline-flex;align-items:center;gap:8px;font-family:var(--mono);font-size:15px;font-weight:600;background:linear-gradient(180deg,var(--accent-soft),var(--accent) 52%,var(--accent-deep));color:#fff;border-radius:12px;padding:16px 28px;margin-top:28px;text-decoration:none;box-shadow:inset 0 1px 0 rgba(255,255,255,.28),0 14px 34px -16px rgba(58,48,184,.8);transition:transform .3s var(--ease),box-shadow .3s var(--ease);will-change:transform}
+  .cta:hover{transform:translateY(-2px);box-shadow:inset 0 1px 0 rgba(255,255,255,.34),0 20px 46px -18px rgba(58,48,184,.92)}
+  .cta:active{transform:translateY(0) scale(.985)}
   .cta-note{font-family:var(--mono);font-size:12px;color:var(--ink-soft);margin-top:16px}
   footer{border-top:1px solid var(--line);padding:30px 0;font-size:13px;color:var(--ink-soft)}
   .foot-inner{display:flex;justify-content:space-between;flex-wrap:wrap;gap:12px;align-items:center}
@@ -251,8 +263,8 @@
   .cmd-group h4 .n{color:var(--ink-dim);font-weight:400}
   .cmd-group h4::after{content:"";flex:1;height:1px;background:var(--line)}
   .cmd-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(248px,1fr));gap:9px}
-  .cmd-item{border:1px solid var(--line);border-radius:9px;padding:11px 13px;background:var(--bg2);transition:border-color .15s,transform .15s}
-  .cmd-item:hover{border-color:var(--accent);transform:translateY(-1px)}
+  .cmd-item{border:1px solid var(--line);border-radius:9px;padding:11px 13px;background:var(--bg2);transition:border-color .25s var(--ease),transform .25s var(--ease),background .25s var(--ease)}
+  .cmd-item:hover{border-color:color-mix(in srgb,var(--accent) 55%,var(--line));background:color-mix(in srgb,var(--accent) 6%,var(--bg2));transform:translateY(-2px)}
   .cmd-item .cn{font-family:var(--mono);font-size:13px;color:var(--ink);font-weight:500}
   .cmd-item .cd{font-size:12px;color:var(--ink-soft);margin-top:3px;line-height:1.42}
 
@@ -280,6 +292,7 @@
 </head>
 <body>
 <a class="skip" href="#install">Skip to install</a>
+<div class="grain" aria-hidden="true"></div>
 <div class="tilt-layer">
 
 <nav><div class="wrap nav-inner">
@@ -675,6 +688,27 @@
     else if((!vis||reduceMotion) && raf){ cancelAnimationFrame(raf); raf=0; }
   }).observe(cv);
   draw();
+
+  // ---- premium pointer FX ----
+  const fxReduce = matchMedia('(prefers-reduced-motion: reduce)').matches;
+  // cursor spotlight: track local coords on each figure card (CSS reads --mx/--my)
+  document.querySelectorAll('.fig').forEach(card=>{
+    let rf=0;
+    card.addEventListener('pointermove',e=>{ if(rf) return; rf=requestAnimationFrame(()=>{ rf=0;
+      const r=card.getBoundingClientRect();
+      card.style.setProperty('--mx',(e.clientX-r.left)+'px');
+      card.style.setProperty('--my',(e.clientY-r.top)+'px'); }); });
+    card.addEventListener('pointerleave',()=>{ card.style.setProperty('--mx','50%'); card.style.setProperty('--my','0%'); });
+  });
+  // magnetic pull on the closing CTA (skip under reduced-motion)
+  if(!fxReduce) document.querySelectorAll('.cta').forEach(btn=>{
+    let rf=0;
+    btn.addEventListener('pointermove',e=>{ if(rf) return; rf=requestAnimationFrame(()=>{ rf=0;
+      const r=btn.getBoundingClientRect();
+      const dx=(e.clientX-(r.left+r.width/2))*0.22, dy=(e.clientY-(r.top+r.height/2))*0.30;
+      btn.style.transform=`translate(${dx.toFixed(1)}px,${(dy-2).toFixed(1)}px)`; }); });
+    btn.addEventListener('pointerleave',()=>{ btn.style.transform=''; });
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
Ran the UI/UX Pro Max review rubric against the live `site/index.html` and fixed the genuine issues (measured, not guessed).

## Found & fixed
| Priority | Issue | Fix |
|---|---|---|
| §2 CRITICAL | Theme toggle **29×25px**, footer links **31×16px** (under 44px touch min) | `@media(pointer:coarse)` → ≥44px hit areas (theme/copy/footer/CTA) |
| §2 CRITICAL | `.ba` showcase `touch-action:none` **trapped vertical scroll** on mobile | → `pan-y` (page scrolls, slider still drags horizontally) |
| §5/§9 HIGH | Mobile stage: pinned demo unpins, terminal scrolls away from its copy | Hide the shared panel on phones; render each step's terminal **inline** under its block |
| §3 HIGH | Before/after PNGs not lazy-loaded | `loading="lazy"` + `decoding="async"` |
| §1 a11y | Heading skip `h1→h3` at `#stage` | sr-only `<h2>` (outside the grid so layout is untouched) |
| §1 a11y | No skip-to-content | skip-to-install link (visible on focus) |

Left intentionally: mobile section-nav stays hidden — a one-page scroll site with a prominent CTA doesn't need jump-links on a phone, and a hamburger would be over-building.

## Verified
- Console clean; no horizontal scroll
- **Desktop**: panel still pins + populates, grid intact (625/390px ≈ 1.6:1), 0 inline terminals
- **Mobile**: 4 inline terminals built (20 lines), shared panel `display:none`, `touch-action:pan-y`, lazy/async images, skip link + sr-only h2 present
- Note: the `pointer:coarse` touch-target rules are standard CSS that activate on real touch devices (desktop test browsers report `pointer:fine`, so they can't be measured there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility & Mobile Experience**
  * Added a visible “Skip” link and screen-reader-only text, plus consistent `:focus-visible` styling.
  * Improved touch target sizing for coarse-pointer devices.
  * Updated the stage experience on smaller screens to use an inline per-step “mini” terminal view.

* **Performance & Loading**
  * Improved before/after image loading with lazy loading and async decoding.
  * Enabled vertical panning for the compare widget on touch.

* **Visual & Interaction Polish**
  * Refreshed card/call-to-action hover and shadow effects, including pointer spotlight and magnetic CTA behavior (respects reduced-motion).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->