### PR TITLE
fix(site): enlarge the hero logo mark

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -118,6 +118,7 @@
   /* ---------- hero ---------- */
   header.hero{text-align:center;padding:62px 0 36px}
   .lockup{display:flex;flex-direction:column;align-items:center;gap:16px;margin-bottom:30px}
+  .lockup #heromark svg{width:clamp(96px,11vw,120px);height:clamp(96px,11vw,120px)}  /* enlarge the hero mark (base render is 76px) */
   .lockup .wordmark{font-size:clamp(26px,5vw,38px);font-weight:500}
   .wm-rule{width:26px;height:3px;background:var(--accent);border-radius:2px}
   .eyebrow{font-family:var(--mono);font-size:13px;letter-spacing:.13em;color:var(--ink-soft)}


### PR DESCRIPTION
Bumps the hero blueprint mark from 76px to a responsive clamp(96px, 11vw, 120px) so the logo reads more prominently above the wordmark. CSS-only — the SVG viewBox scales it proportionally, the click-to-replay animation is unaffected, and the nav + closing marks are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)